### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/Lab_01_organization_setup.md
+++ b/Instructions/Labs/Lab_01_organization_setup.md
@@ -1,8 +1,18 @@
 ---
-lab  : 
-    title: 'Lab 1: Organization Setup'
-    module: 'Module 3: Configure organization setup and structure'
+lab:
+  title: 'Lab 1: Organization Setup'
+  module: 'Module 3: Configure organization setup and structure'
+  description: In this lab for Microsoft Cloud for Sustainability, you'll use demo
+    data to set up the "Set up organization and reference data" scenario. Contoso
+    Corp is a specialty coffee distribution business with operations in APAC, US,
+    Africa, and Europe.
+  duration: 152 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Microsoft Cloud for Sustainability
 ---
+
 # Module 3 Lesson 2 Lab 1: Organization Setup
 
 ## Overview

--- a/Instructions/Labs/Lab_02_data_ingestion.md
+++ b/Instructions/Labs/Lab_02_data_ingestion.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Lab 2: Data ingestion'
-    module: 'Module 4: Configure data ingestion'
+  title: 'Lab 2: Data ingestion'
+  module: 'Module 4: Configure data ingestion'
+  description: In the previous lab, Wide Word Importers’ company profile, facilities,
+    and reference data such as Contractual instrument types were created to lay the
+    Master data foundation for Emissions calculations and Reporting. In this lab -
+    we will perform the Activity data ingestion for the Purchased Electricity of the
+    two newly acquired Florida facilities. In addition, we will also ingest emission
+    data related to the charging of the fleet of 50 Fabrikam Electric trucks. The
+    built-in connectors in the Microsoft Sustainability Manager will be used to ingest
+    the Activity data into the application.
+  duration: 150 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 4 Lesson 2 Lab 2: Data ingestion

--- a/Instructions/Labs/Lab_03_emission_calculations.md
+++ b/Instructions/Labs/Lab_03_emission_calculations.md
@@ -1,8 +1,19 @@
 ---
 lab:
-    title: 'Lab 3: Design Emission calculations'
-    module: 'Module 5: Configure emission calculations'
+  title: 'Lab 3: Design Emission calculations'
+  module: 'Module 5: Configure emission calculations'
+  description: In the previous two labs, we laid the foundation for emission calculations
+    by setting up the organization, reference data such as Contractual instrument
+    types and ingesting the Activity data. Now that the groundwork and data has been
+    laid for emission calculations, this lab will focus on performing the emission
+    calculations using a combination of factor libraries, emission factors, estimation
+    factors and calculation profiles. Once the calculations are performed, we will
+    review the emission calculations output.
+  duration: 6 minutes
+  level: 200
+  islab: true
 ---
+
 # Module 5 Lesson 2 Lab 3: Design Emission calculations
 
 ## Overview

--- a/Instructions/Labs/Lab_04_insights_and_reporting.md
+++ b/Instructions/Labs/Lab_04_insights_and_reporting.md
@@ -1,8 +1,18 @@
 ---
 lab:
-    title: 'Lab 4: Insights and reporting'
-    module: 'Module 6: Configure insights and reporting'
+  title: 'Lab 4: Insights and reporting'
+  module: 'Module 6: Configure insights and reporting'
+  description: In the previous lab, the ingested Activity data was taken through calculation
+    designs using calculation models and the output was reviewed in terms of CO<sub>2</sub>E
+    unit. In this lab, we will perform a set of activities to generate emissions reports,
+    activity reports, and review Power BI dashboards.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
+
 # Module 6 Lesson 2 Lab 4: Insights and reporting
 
 ## Overview

--- a/Instructions/Labs/Lab_05_goals_and_scorecard.md
+++ b/Instructions/Labs/Lab_05_goals_and_scorecard.md
@@ -1,8 +1,18 @@
 ---
 lab:
-    title: 'Lab 5: Goals and scorecards'
-    module: 'Module 7: Configure goals and scorecards'
+  title: 'Lab 5: Goals and scorecards'
+  module: 'Module 7: Configure goals and scorecards'
+  description: In the previous four labs, the master and system data were set up and
+    calculations performed to report on emissions. In this lab, the focus is on setting
+    carbon emission reduction goals and tracking them using scorecards. In the scorecard,
+    emission reduction goals can be introduced based on the organization’s sustainability
+    priorities and can be collaboratively tracked with various stakeholders using
+    the Teams collaboration feature.
+  duration: 150 minutes
+  level: 100
+  islab: true
 ---
+
 # Module 7 Lesson 2 Lab 5: Goals and scorecard
 
 ## Overview


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/Lab_01_organization_setup.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab_02_data_ingestion.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_03_emission_calculations.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_04_insights_and_reporting.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab_05_goals_and_scorecard.md` (description,duration,level,islab)
