### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/Lab_02_data_ingestion.md
+++ b/Instructions/Labs/Lab_02_data_ingestion.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 2: Data ingestion'
-    module: 'Module 4: Configure data ingestion'
+  title: 'Lab 2: Data ingestion'
+  module: 'Module 4: Configure data ingestion'
+  description: In the previous lab, Wide Word Importers’ company profile, facilities, and reference data such as Contractual instrument types were created to lay the Master data foundation for Emissions calculations and Reporting. In this lab - we will perform the Activity data ingestion for the Purchased Electricity of the two newly acquired Florida facilities. In addition, we will also ingest emission data related to the charging of the fleet of 50 Fabrikam Electric trucks. The built-in connectors in the Microsoft Sustainability Manager will be used to ingest the Activity data into the application.
+  duration: 150 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 4 Lesson 2 Lab 2: Data ingestion

--- a/Instructions/Labs/Lab_03_emission_calculations.md
+++ b/Instructions/Labs/Lab_03_emission_calculations.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Lab 3: Design Emission calculations'
-    module: 'Module 5: Configure emission calculations'
+  title: 'Lab 3: Design Emission calculations'
+  module: 'Module 5: Configure emission calculations'
+  description: By creating these factor mappings, we can choose Contractual Instrument Types as emission factor during our calculation model creation. This tells Microsoft Sustainability Manager to map the contractual instrument type on an activity data record to the emission factor listed in the factor mapping. This allows you to create more dynamic calculations rather than calculations specific to a given emission factor. We will go into more detail on this later in this lab. Please continue to the next task.
+  duration: 6 minutes
+  level: 200
+  islab: true
 ---
+
 # Module 5 Lesson 2 Lab 3: Design Emission calculations
 
 ## Overview

--- a/Instructions/Labs/Lab_04_insights_and_reporting.md
+++ b/Instructions/Labs/Lab_04_insights_and_reporting.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Lab 4: Insights and reporting'
-    module: 'Module 6: Configure insights and reporting'
+  title: 'Lab 4: Insights and reporting'
+  module: 'Module 6: Configure insights and reporting'
+  description: In this lab, Amber Rodriguez – Sustainability specialist for Contoso Corp reviews the data in the Insights section of Microsoft Sustainability Manager, noticing that Wide World Importers was a large contributor to Scope 2 emissions in 2022. Amber informs Jessie Irwin - Sustainability lead for Contoso Corp that the Activity and Emission Reports are available for review. Jessie opens the reporting section and creates a new Activity report and a new Emissions report. Jessie reviews the generated report and includes the report in the sustainability reporting procedures for Contoso Corp.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
+
 # Module 6 Lesson 2 Lab 4: Insights and reporting
 
 ## Overview

--- a/Instructions/Labs/Lab_05_goals_and_scorecard.md
+++ b/Instructions/Labs/Lab_05_goals_and_scorecard.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Lab 5: Goals and scorecards'
-    module: 'Module 7: Configure goals and scorecards'
+  title: 'Lab 5: Goals and scorecards'
+  module: 'Module 7: Configure goals and scorecards'
+  description: 'In this exercise, you will learn about the steps that Amber takes to create scorecards and goals to help Wide World Importers track carbon reduction progress. Based on the results of the previous lab, Amber has determined that Wide World Importers needs to reduce their Scope 2: Purchased electricity carbon emissions. Scorecards and goals allow organizations to set carbon reduction targets and track their progress to that. You can explore this functionality in deeper detail on Microsoft Docs, please visit Overview of scorecards and goals https://docs.microsoft.com/en-us/industry/sustainability/reports-scorecards-goals.'
+  duration: 150 minutes
+  level: 100
+  islab: true
 ---
+
 # Module 7 Lesson 2 Lab 5: Goals and scorecard
 
 ## Overview


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/Lab_02_data_ingestion.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_03_emission_calculations.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_04_insights_and_reporting.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_05_goals_and_scorecard.md` (description,duration,level,islab)
